### PR TITLE
Support fpath config keyword for match against file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,6 @@ succeed in the heroic task of compiling libmagic for Windows and teach
 [with Go](https://github.com/golang/go/issues/31529), see
 [#6](https://github.com/doronbehar/pistol/issues/6) for more details. [↩](#a3)
 
-<b id="f4">4</b>I don't use Ranger anymore, ever since I moved to Lf. If you
+<b id="f4">4</b> I don't use Ranger anymore, ever since I moved to Lf. If you
 have evidence it does support 256 colors, let me know and I'll change the
 default. [↩](#a4)

--- a/previewer.go
+++ b/previewer.go
@@ -74,6 +74,8 @@ func NewPreviewer(filePath, configPath string) (Previewer, error) {
 			log.Infof("previewer's command is %s %s\n", p.command, p.args)
 			return p, nil
 		}
+		// Test if fpath keyword is used at the beginning, indicating it's a
+		// file path match we should be looking for
 		if def[0] == "fpath" {
 			log.Infof("found 'fpath' at the beginning, testing match against file path")
 		}

--- a/previewer.go
+++ b/previewer.go
@@ -76,14 +76,16 @@ func NewPreviewer(filePath, configPath string) (Previewer, error) {
 		}
 		// Test if fpath keyword is used at the beginning, indicating it's a
 		// file path match we should be looking for
-		if def[0] == "fpath" {
+		if def[0] == "fpath" && len(def) > 2 {
 			log.Infof("found 'fpath' at the beginning, testing match against file path")
+		} else {
+			break
 		}
 		match, err = regexp.MatchString(def[1], filePath)
 		if err != nil {
 			return p, err
 		}
-		if match && len(def) > 2 {
+		if match {
 			log.Infof("matched file path match against filePath")
 			p.command = def[2]
 			for _, arg := range def[3:] {

--- a/previewer.go
+++ b/previewer.go
@@ -74,6 +74,26 @@ func NewPreviewer(filePath, configPath string) (Previewer, error) {
 			log.Infof("previewer's command is %s %s\n", p.command, p.args)
 			return p, nil
 		}
+		if def[0] == "fpath" {
+			log.Infof("found 'fpath' at the beginning, testing match against file path")
+		}
+		match, err = regexp.MatchString(def[1], filePath)
+		if err != nil {
+			return p, err
+		}
+		if match && len(def) > 2 {
+			log.Infof("matched file path match against filePath")
+			p.command = def[2]
+			for _, arg := range def[3:] {
+				if match, _ := regexp.MatchString("%s", arg); match {
+					p.args = append(p.args, fmt.Sprintf(arg, filePath))
+				} else {
+					p.args = append(p.args, arg)
+				}
+			}
+			log.Infof("previewer's command is %s %s\n", p.command, p.args)
+			return p, nil
+		}
 	}
 	log.Infof("didn't find a match in configuration for detected mimetype: %s\n", p.mimeType)
 	return p, nil


### PR DESCRIPTION
Fixes https://github.com/doronbehar/pistol/issues/9 .

@smhmd could you please test this? You should be able to build `pistol` with:

```
git clone -b filepath-config-match https://github.com/doronbehar/pistol
cd pistol/cmd/pistol
go install
```

And use the following in your config:

```
fpath .*\.md bat --style=plain --paging=never --color=always %s
```

(That's what I tested).

Or for `mdcat`:

```
fpath .*\.md mdcat %s
```

(Untested).