### PR TITLE
Sh in config

### DIFF
--- a/previewer.go
+++ b/previewer.go
@@ -72,7 +72,6 @@ func NewPreviewer(filePath, configPath string) (Previewer, error) {
 					p.args = append(p.args, arg)
 				}
 			}
-			log.Infof("previewer's command is %s %s\n", p.command, p.args)
 			return p, nil
 		}
 		// Test if fpath keyword is used at the beginning, indicating it's a
@@ -107,7 +106,6 @@ func NewPreviewer(filePath, configPath string) (Previewer, error) {
 					p.args = append(p.args, arg)
 				}
 			}
-			log.Infof("previewer's command is %s %s\n", p.command, p.args)
 			return p, nil
 		}
 	}
@@ -118,7 +116,14 @@ func NewPreviewer(filePath, configPath string) (Previewer, error) {
 func (p *Previewer) Write(w io.Writer) (error) {
 	// if a match was encountered when the configuration file was read
 	if p.command != "" {
-		cmd := exec.Command(p.command, p.args...)
+		var cmd *exec.Cmd
+		if p.command == "sh:" {
+			log.Infof("previewer's command is (shell interpreted): %s\n", p.args[0:])
+			cmd = exec.Command("sh", "-c", strings.Join(p.args[0:], " "))
+		} else {
+			log.Infof("previewer's command is %s %s\n", p.command, strings.Join(p.args, " "))
+			cmd = exec.Command(p.command, p.args...)
+		}
 		cmd.Stdout = w
 		cmd.Stderr = os.Stderr
 		if err := cmd.Start(); err != nil {

--- a/previewer.go
+++ b/previewer.go
@@ -120,6 +120,7 @@ func (p *Previewer) Write(w io.Writer) (error) {
 	if p.command != "" {
 		cmd := exec.Command(p.command, p.args...)
 		cmd.Stdout = w
+		cmd.Stderr = os.Stderr
 		if err := cmd.Start(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Enable to use `sh:` prefix for commands to signal pistol to use `sh -c` to run commands - Fixes https://github.com/doronbehar/pistol/issues/12 & Fixes #15 . Test it with e.g:

```
fpath .*.md$ sh: bat --paging=never --color=always %s | head -8
```

On a markdown file such as this repo's README. Please test other usages as well.

TODO:

- [x] Update README.