### PR TITLE
Archives: Put less info in modification time column 

### DIFF
--- a/internal_writers/archives.go
+++ b/internal_writers/archives.go
@@ -104,7 +104,9 @@ func NewArchiveLister(mimeType, filePath string) (func(w io.Writer) error, error
 			err := walker.Walk(filePath, func(f archiver.File) error {
 				fPerm := fmt.Sprintf("%v", f.Mode())
 				fSize := humanize.Bytes(uint64(f.Size()))
-				fModt := fmt.Sprintf("%v", f.ModTime())
+				fModtS := f.ModTime()
+				fModt := fmt.Sprintf("%04d-%02d-%02d %02d:%02d", fModtS.Year(), fModtS.Month(),
+				fModtS.Day(), fModtS.Hour(), fModtS.Minute())
 				var fName string
 				switch h := f.Header.(type) {
 				case zip.FileHeader:


### PR DESCRIPTION
@lucas-mior How do you like this:

```
Permissions   Size     Modification Time  File Name
============  =======  =================  ==========
drwxr-xr-x    0 B      2020-03-13 09:43   META-INF/
...
```

? It's shorter in 12 characters.