### PR TITLE
fix: remove %pistol-extra% arguments when not passed to pistol

### DIFF
--- a/previewer.go
+++ b/previewer.go
@@ -173,19 +173,21 @@ func (p *Previewer) Write(w io.Writer) (error) {
 					// We try to convert the string found in the argument to a
 					// number.
 					auxInt, err := strconv.Atoi(arg[loc[2]:loc[3]])
+					current := arg[loc[0]:loc[1]]
 					if (err == nil && len(p.Extras) > auxInt) {
 						// substitute the %pistol-extra[#]% argument in the
 						// final CLI string.
-						current := arg[loc[0]:loc[1]]
 						argAux = strings.ReplaceAll(argAux, current, p.Extras[auxInt])
 					} else {
-						continue
+						argAux = strings.ReplaceAll(argAux, current, "")
 					}
 				}
 			} else {
 				argAux = strings.ReplaceAll(argAux, "%pistol-filename%", replStr)
 			}
-			argsOut = append(argsOut, argAux)
+			if(len(argAux) > 0) {
+				argsOut = append(argsOut, argAux)
+			}
 		}
 
 		if p.Command == "sh:" {


### PR DESCRIPTION
Although it took long for me to notice it,
my last PR introduced a bug which would cause trouble when invoking `pistol` without extra arguments (and the config expected those). Basically, it would pass, for example, "%pistol-extra3%", literally, instead of the argument (because it wasn't there), instead of just removing it from the arguments array.
The solution, as can be read in the code, is to make the argument an empty string and then, when appending to the other arguments, check if it is empty before doing so.