### PR TITLE
Update from-source installation instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -160,14 +160,14 @@ Assuming you've installed `libmagic` properly and you have
 https://golang.org/doc/install[setup a Go environment], Use the
 following command to install Pistol to `$GOPATH/bin/pistol`:
 
-==== Go 1.17 or later
+==== Go 1.16 or later
 
 [source,sh]
 ----
 go install github.com/doronbehar/pistol/cmd/pistol@latest
 ----
 
-==== Go 1.16 or earlier
+==== Go 1.15 or earlier
 
 [source,sh]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -160,6 +160,15 @@ Assuming you've installed `libmagic` properly and you have
 https://golang.org/doc/install[setup a Go environment], Use the
 following command to install Pistol to `$GOPATH/bin/pistol`:
 
+==== Go 1.17 or later
+
+[source,sh]
+----
+go install github.com/doronbehar/pistol/cmd/pistol@latest
+----
+
+==== Go 1.16 or earlier
+
 [source,sh]
 ----
 env CGO_ENABLED=1 GO111MODULE=on go get -u github.com/doronbehar/pistol/cmd/pistol


### PR DESCRIPTION
"go get" is deprecated.

https://go.dev/doc/go-get-install-deprecation

These updated instructions are correct for Go 1.17.6, which is what I currently have on OS X.