### PR TITLE
Update default macOS config location in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -273,7 +273,8 @@ You can change this behaviour by writing a configuration file in
 GNU systems, with the syntax as explained below.
 
 NOTE: On OS X, this location defaults to:
-`~/Library/Preferences/pistol/pistol.conf`, as the XDG specification imposes.
+`~/Library/Application Support/pistol/pistol.conf`, as the XDG specification
+imposes.
 
 === Syntax
 


### PR DESCRIPTION
~/Library/Preferences/ is not actually the default; it is one of the fallback directories used by github.com/adrg/xdg when `XDG_CONFIG_DIRS` is unset. If `XDG_CONFIG_DIRS` is set and does not contain ~/Library/Preferences/, that directory is never consulted.

Rather, the default value of `XDG_CONFIG_HOME` is what should be considered the default, which is ~/Library/Application Support/ instead.

Link: nix-community/home-manager#9798